### PR TITLE
Add example playbook for creating host record

### DIFF
--- a/playbooks/create_host_record.yaml
+++ b/playbooks/create_host_record.yaml
@@ -1,0 +1,20 @@
+---
+- name: Infoblox Member Configuration
+  hosts: localhost
+  vars:
+    nios_provider:
+      host: 10.36.118.2
+      username: cloudadmin
+      password: admin
+
+  connection: local
+  tasks:
+    - name: Create Nios Host Record
+      infoblox.nios_modules.nios_host_record:
+        name: host.ansibletestzone.com
+        view: ansibleDnsView
+        ipv4addrs:
+          - ipv4addr: 192.168.11.251
+        comment: Created with Ansible
+        state: present
+        provider: "{{ nios_provider }}"


### PR DESCRIPTION
add host record example playbook written in Ansible.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tblakex01/infoblox-ansible?shareId=7591ee93-7bc4-44b4-848b-005427ce905d).

## Summary by Sourcery

New Features:
- Introduce an example Ansible playbook for creating a host record using Infoblox.